### PR TITLE
feat: 扩展工作站 GT 工具槽与工具配方支持

### DIFF
--- a/src/main/java/slimeknights/tconstruct/mixin/gtceu/ToolIngredientAccess.java
+++ b/src/main/java/slimeknights/tconstruct/mixin/gtceu/ToolIngredientAccess.java
@@ -1,0 +1,13 @@
+package slimeknights.tconstruct.mixin.gtceu;
+
+import com.gregtechceu.gtceu.api.item.tool.GTToolType;
+import com.gregtechceu.gtceu.api.recipe.ingredient.ToolIngredient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(value = ToolIngredient.class)
+/** Mixin bridge for the GT ingredient's otherwise private tool type. */
+public interface ToolIngredientAccess {
+  @Accessor(value = "toolType", remap = false)
+  GTToolType tconstruct$getToolType();
+}

--- a/src/main/java/slimeknights/tconstruct/mixin/gtceu/ToolIngredientMixin.java
+++ b/src/main/java/slimeknights/tconstruct/mixin/gtceu/ToolIngredientMixin.java
@@ -10,8 +10,8 @@ import slimeknights.tconstruct.library.tools.helper.ToolDamageUtil;
 import slimeknights.tconstruct.library.tools.item.ModifiableItem;
 
 @Mixin(value = ToolIngredient.class)
-public abstract class ToolIngredientMixin {
-  @Inject(method = "test", at = @At("HEAD"), cancellable = true)
+public abstract class ToolIngredientMixin{
+  @Inject(method = "test(Lnet/minecraft/world/item/ItemStack;)Z", at = @At("HEAD"), cancellable = true)
   private void tconstruct$rejectBrokenTool(ItemStack input, CallbackInfoReturnable<Boolean> cir) {
     if (input != null && input.getItem() instanceof ModifiableItem && ToolDamageUtil.isBroken(input)) {
       cir.setReturnValue(false);

--- a/src/main/java/slimeknights/tconstruct/plugin/emi/CraftingStationEmiRecipeHandler.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/emi/CraftingStationEmiRecipeHandler.java
@@ -1,9 +1,18 @@
 package slimeknights.tconstruct.plugin.emi;
 
 import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.recipe.EmiPlayerInventory;
 import dev.emi.emi.api.recipe.VanillaEmiRecipeCategories;
 import dev.emi.emi.api.recipe.handler.StandardRecipeHandler;
+import dev.emi.emi.api.stack.EmiStack;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+import com.gregtechceu.gtceu.api.recipe.ingredient.ToolIngredient;
 import net.minecraft.world.inventory.Slot;
+import slimeknights.tconstruct.tables.block.entity.table.CraftingStationBlockEntity;
+import slimeknights.tconstruct.tables.menu.slot.PlayerSensitiveLazyResultSlot;
 import slimeknights.tconstruct.tables.menu.CraftingStationContainerMenu;
 
 import java.util.ArrayList;
@@ -21,10 +30,62 @@ public class CraftingStationEmiRecipeHandler implements StandardRecipeHandler<Cr
     return menu.slots.subList(0, 9);
   }
 
-  /** 成品槽:菜单第 10 个槽 */
+  /** Maps GT tool ingredients to the dedicated tool slots during EMI transfer. */
+  @Override
+  public List<Slot> getCraftingSlots(EmiRecipe emiRecipe, CraftingStationContainerMenu menu) {
+    if (!(emiRecipe.getBackingRecipe() instanceof CraftingRecipe recipe)) {
+      return getCraftingSlots(menu);
+    }
+    List<Ingredient> ingredients = recipe.getIngredients();
+    int inputCount = emiRecipe.getInputs().size();
+    List<Slot> slots = new ArrayList<>(inputCount);
+    boolean[] claimedTools = new boolean[CraftingStationBlockEntity.TOOL_SLOT_COUNT];
+    int toolIndex = 0;
+    int normalIndex = 0;
+    boolean shaped = recipe instanceof ShapedRecipe;
+    for (int i = 0; i < inputCount; i++) {
+      Ingredient ingredient = i < ingredients.size() ? ingredients.get(i) : Ingredient.EMPTY;
+      if (ingredient instanceof ToolIngredient) {
+        if (toolIndex >= CraftingStationBlockEntity.TOOL_SLOT_COUNT) return getCraftingSlots(menu);
+        int destination = findToolDestination(menu, ingredient, claimedTools);
+        if (destination < 0) return getCraftingSlots(menu);
+        claimedTools[destination] = true;
+        slots.add(menu.getSlot(CraftingStationBlockEntity.TOOL_SLOT_START + destination));
+        toolIndex++;
+      } else if (shaped) {
+        slots.add(menu.getSlot(i));
+      } else {
+        // Shapeless EMI inputs are compacted; map ordinary ingredients to the first
+        // available grid slots while tools are routed to tool slots above.
+        while (normalIndex < 9 && menu.getSlot(normalIndex).hasItem()) normalIndex++;
+        slots.add(menu.getSlot(Math.min(normalIndex++, 8)));
+      }
+    }
+    return slots;
+  }
+
+  /** Keep an already matching tool in place; otherwise use an empty slot. */
+  private static int findToolDestination(CraftingStationContainerMenu menu, Ingredient requirement,
+                                         boolean[] claimed) {
+    for (int pass = 0; pass < 2; pass++) {
+      for (int i = 0; i < claimed.length; i++) {
+        if (claimed[i]) continue;
+        Slot slot = menu.getSlot(CraftingStationBlockEntity.TOOL_SLOT_START + i);
+        boolean matching = !slot.getItem().isEmpty() && requirement.test(slot.getItem().copy());
+        boolean empty = slot.getItem().isEmpty();
+        if ((pass == 0 && matching) || (pass == 1 && empty)) return i;
+      }
+    }
+    return -1;
+  }
+
+  /** 成品槽:工具槽之后的惰性结果槽 */
   @Override
   public Slot getOutputSlot(CraftingStationContainerMenu menu) {
-    return menu.slots.get(9);
+    for (Slot slot : menu.slots) {
+      if (slot instanceof PlayerSensitiveLazyResultSlot) return slot;
+    }
+    return menu.slots.get(CraftingStationBlockEntity.CRAFTING_SLOT_COUNT + CraftingStationBlockEntity.TOOL_SLOT_COUNT);
   }
 
   /**
@@ -39,7 +100,11 @@ public class CraftingStationEmiRecipeHandler implements StandardRecipeHandler<Cr
     for (int i = 0; i < 9; i++) {
       slots.add(menu.getSlot(i));
     }
-    for (int i = 9; i < playerStart; i++) {
+    // Side inventories remain additional sources. Installed tool slots are appended only
+    // as a fallback source, after player/connected inventories, so EMI does not pull an
+    // already-installed tool out of its slot when switching between recipes.
+    int sideStart = CraftingStationBlockEntity.CRAFTING_SLOT_COUNT + CraftingStationBlockEntity.TOOL_SLOT_COUNT + 1;
+    for (int i = sideStart; i < playerStart; i++) {
       Slot slot = menu.getSlot(i);
       // 跳过空槽,避免把物品放入空槽造成困惑
       if (slot.hasItem()) {
@@ -49,7 +114,21 @@ public class CraftingStationEmiRecipeHandler implements StandardRecipeHandler<Cr
     for (int i = playerStart; i < totalSize; i++) {
       slots.add(menu.getSlot(i));
     }
+    for (int i = 0; i < CraftingStationBlockEntity.TOOL_SLOT_COUNT; i++) {
+      Slot slot = menu.getSlot(CraftingStationBlockEntity.TOOL_SLOT_START + i);
+      if (slot.hasItem()) slots.add(slot);
+    }
     return slots;
+  }
+
+  /** Includes installed tools in EMI's availability and transfer calculation. */
+  @Override
+  public EmiPlayerInventory getInventory(AbstractContainerScreen<CraftingStationContainerMenu> screen) {
+    List<EmiStack> stacks = new ArrayList<>();
+    for (Slot slot : getInputSources(screen.getMenu())) {
+      if (slot.hasItem()) stacks.add(EmiStack.of(slot.getItem()));
+    }
+    return new EmiPlayerInventory(stacks);
   }
 
   @Override

--- a/src/main/java/slimeknights/tconstruct/plugin/polymorph/CraftingStationRecipeData.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/polymorph/CraftingStationRecipeData.java
@@ -19,6 +19,7 @@ import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import slimeknights.tconstruct.tables.block.entity.table.CraftingStationBlockEntity;
+import slimeknights.tconstruct.tables.recipe.ToolCraftingResolver;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -208,6 +209,10 @@ public class CraftingStationRecipeData implements IBlockEntityRecipeData {
     Level level = tile.getLevel();
     if (level != null) {
       for (CraftingRecipe recipe : level.getRecipeManager().getRecipesFor(RecipeType.CRAFTING, tile.getCraftingInventory(), level)) {
+        pairs.add(new RecipePair(recipe.getId(), recipe.getResultItem(level.registryAccess())));
+      }
+      for (ToolCraftingResolver.Match match : ToolCraftingResolver.findMatches(tile, level)) {
+        CraftingRecipe recipe = match.recipe();
         pairs.add(new RecipePair(recipe.getId(), recipe.getResultItem(level.registryAccess())));
       }
     }

--- a/src/main/java/slimeknights/tconstruct/tables/block/entity/inventory/CraftingContainerWrapper.java
+++ b/src/main/java/slimeknights/tconstruct/tables/block/entity/inventory/CraftingContainerWrapper.java
@@ -17,22 +17,30 @@ import java.util.List;
  */
 public class CraftingContainerWrapper implements CraftingContainer {
   private final Container crafter;
+  private final int offset;
   @Getter
   private final int width;
   @Getter
   private final int height;
   public CraftingContainerWrapper(Container crafter, int width, int height) {
-    Preconditions.checkArgument(crafter.getContainerSize() == width * height, "Invalid width and height for inventroy size");
+    this(crafter, width, height, 0);
+  }
+
+  /** Creates a view over a rectangular range in the backing container. */
+  public CraftingContainerWrapper(Container crafter, int width, int height, int offset) {
+    Preconditions.checkArgument(offset >= 0 && crafter.getContainerSize() >= offset + width * height,
+      "Invalid width and height for inventory size");
     this.crafter = crafter;
     this.width = width;
     this.height = height;
+    this.offset = offset;
   }
 
   /** Inventory redirection */
 
   @Override
   public ItemStack getItem(int index) {
-    return crafter.getItem(index);
+    return crafter.getItem(index + offset);
   }
 
   @Override
@@ -47,17 +55,17 @@ public class CraftingContainerWrapper implements CraftingContainer {
 
   @Override
   public ItemStack removeItemNoUpdate(int index) {
-    return crafter.removeItemNoUpdate(index);
+    return crafter.removeItemNoUpdate(index + offset);
   }
 
   @Override
   public ItemStack removeItem(int index, int count) {
-    return crafter.removeItem(index, count);
+    return crafter.removeItem(index + offset, count);
   }
 
   @Override
   public void setItem(int index, ItemStack stack) {
-    crafter.setItem(index, stack);
+    crafter.setItem(index + offset, stack);
   }
 
   @Override
@@ -77,8 +85,8 @@ public class CraftingContainerWrapper implements CraftingContainer {
 
   @Override
   public void fillStackedContents(StackedContents helper) {
-    for (int i = 0; i < crafter.getContainerSize(); i++) {
-      helper.accountSimpleStack(crafter.getItem(i));
+    for (int i = 0; i < getContainerSize(); i++) {
+      helper.accountSimpleStack(crafter.getItem(i + offset));
     }
   }
 

--- a/src/main/java/slimeknights/tconstruct/tables/block/entity/table/CraftingStationBlockEntity.java
+++ b/src/main/java/slimeknights/tconstruct/tables/block/entity/table/CraftingStationBlockEntity.java
@@ -28,12 +28,17 @@ import slimeknights.tconstruct.tables.block.entity.inventory.LazyResultContainer
 import slimeknights.tconstruct.tables.block.entity.inventory.LazyResultContainer.ILazyCrafter;
 import slimeknights.tconstruct.tables.menu.CraftingStationContainerMenu;
 import slimeknights.tconstruct.tables.network.UpdateCraftingRecipePacket;
+import slimeknights.tconstruct.tables.recipe.ToolCraftingResolver;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
+import java.util.ArrayList;
 
 public class CraftingStationBlockEntity extends RetexturedTableBlockEntity implements ILazyCrafter {
+  public static final int CRAFTING_SLOT_COUNT = 9;
+  public static final int TOOL_SLOT_COUNT = 9;
+  public static final int TOOL_SLOT_START = CRAFTING_SLOT_COUNT;
   public static final Component UNCRAFTABLE = TConstruct.makeTranslation("gui", "crafting_station.uncraftable");
   private static final Component NAME = TConstruct.makeTranslation("gui", "crafting_station");
 
@@ -54,6 +59,12 @@ public class CraftingStationBlockEntity extends RetexturedTableBlockEntity imple
   /** Last crafted crafting recipe */
   @Nullable
   private CraftingRecipe lastRecipe;
+  /** Resolved virtual-input match when the selected recipe uses dedicated GT tool slots. */
+  @Nullable
+  private ToolCraftingResolver.Match lastToolMatch;
+  /** Cached tool-recipe candidates; invalidated only when station inputs change. */
+  @Nullable
+  private List<ToolCraftingResolver.Match> cachedToolMatches;
   /** Result inventory, lazy loads results */
   @Getter
   private final LazyResultContainer craftingResult;
@@ -64,11 +75,19 @@ public class CraftingStationBlockEntity extends RetexturedTableBlockEntity imple
   private final CraftingContainerWrapper craftingInventory;
 
   public CraftingStationBlockEntity(BlockPos pos, BlockState state) {
-    super(TinkerTables.craftingStationTile.get(), pos, state, NAME, 9);
+    super(TinkerTables.craftingStationTile.get(), pos, state, NAME, CRAFTING_SLOT_COUNT + TOOL_SLOT_COUNT);
     this.itemHandler = new ConfigurableInvWrapperCapability(this, false, false);
     this.itemHandlerCap = LazyOptional.of(() -> this.itemHandler);
-    this.craftingInventory = new CraftingContainerWrapper(this, 3, 3);
+    this.craftingInventory = new CraftingContainerWrapper(this, 3, 3, 0);
     this.craftingResult = new LazyResultContainer(this);
+  }
+
+  /** Returns a dedicated tool slot stack without exposing it through the crafting grid. */
+  public ItemStack getToolStack(int index) {
+    if (index < 0 || index >= TOOL_SLOT_COUNT) {
+      return ItemStack.EMPTY;
+    }
+    return getItem(TOOL_SLOT_START + index);
   }
 
   @Nullable
@@ -99,19 +118,25 @@ public class CraftingStationBlockEntity extends RetexturedTableBlockEntity imple
       CraftingRecipe recipe = lastRecipe;
       // if it does not match, find a new recipe; plugins may resolve conflicts between the matches
       // note we intentionally have no player access during matches, that could lead to an unstable recipe
-      if (recipe == null || !recipe.matches(this.craftingInventory, this.level)) {
+      if (recipe == null || (lastToolMatch == null && !recipe.matches(this.craftingInventory, this.level))
+          || (lastToolMatch != null && !ToolCraftingResolver.isStillValid(this, lastToolMatch))) {
         List<CraftingRecipe> matches = manager.getRecipesFor(RecipeType.CRAFTING, this.craftingInventory, this.level);
+        List<ToolCraftingResolver.Match> toolMatches = getToolMatches();
+        toolMatches.forEach(match -> { if (!matches.contains(match.recipe())) matches.add(match.recipe()); });
         ICraftingRecipeSelector selector = recipeSelector;
         if (selector != null && !matches.isEmpty()) {
           recipe = selector.selectRecipe(this, this.craftingInventory, matches);
         } else {
           recipe = matches.isEmpty() ? null : matches.get(0);
         }
+        CraftingRecipe selectedRecipe = recipe;
+        lastToolMatch = toolMatches.stream().filter(match -> match.recipe() == selectedRecipe).findFirst().orElse(null);
       }
 
       // if we have a recipe, fetch its result
       if (recipe != null) {
-        result = recipe.assemble(this.craftingInventory, level.registryAccess());
+        result = lastToolMatch == null ? recipe.assemble(this.craftingInventory, level.registryAccess())
+          : recipe.assemble(lastToolMatch.inventory(), level.registryAccess());
 
         // sync if the recipe is different
         if (recipe != lastRecipe) {
@@ -121,9 +146,19 @@ public class CraftingStationBlockEntity extends RetexturedTableBlockEntity imple
       }
       ForgeHooks.setCraftingPlayer(null);
     }
-    else if (this.lastRecipe != null && this.lastRecipe.matches(this.craftingInventory, this.level)) {
+    else if (this.lastRecipe != null) {
+      ToolCraftingResolver.Match toolMatch = lastToolMatch;
+      if (toolMatch == null && !this.lastRecipe.matches(this.craftingInventory, this.level)) {
+        toolMatch = getToolMatches().stream()
+          .filter(match -> match.recipe().getId().equals(this.lastRecipe.getId())).findFirst().orElse(null);
+      }
+      if (toolMatch == null && !this.lastRecipe.matches(this.craftingInventory, this.level)) {
+        return ItemStack.EMPTY;
+      }
       ForgeHooks.setCraftingPlayer(player);
-      result = this.lastRecipe.assemble(this.craftingInventory, level.registryAccess());
+      result = toolMatch == null ? this.lastRecipe.assemble(this.craftingInventory, level.registryAccess())
+        : this.lastRecipe.assemble(toolMatch.inventory(), level.registryAccess());
+      this.lastToolMatch = toolMatch;
       ForgeHooks.setCraftingPlayer(null);
     }
     return result;
@@ -139,9 +174,17 @@ public class CraftingStationBlockEntity extends RetexturedTableBlockEntity imple
     CraftingRecipe recipe = this.lastRecipe; // local variable just to prevent race conditions if the field changes, though that is unlikely
 
     // try matches again now that we have player access
-    if (recipe == null || this.level == null || !recipe.matches(craftingInventory, level)) {
+    if (recipe == null || this.level == null) {
       ForgeHooks.setCraftingPlayer(null);
       return ItemStack.EMPTY;
+    }
+    if (lastToolMatch == null && !recipe.matches(craftingInventory, level)) {
+      lastToolMatch = getToolMatches().stream()
+        .filter(match -> match.recipe().getId().equals(recipe.getId())).findFirst().orElse(null);
+      if (lastToolMatch == null) {
+        ForgeHooks.setCraftingPlayer(null);
+        return ItemStack.EMPTY;
+      }
     }
 
     // check if the player has access to the recipe, if not give up
@@ -163,7 +206,8 @@ public class CraftingStationBlockEntity extends RetexturedTableBlockEntity imple
 //      }
 //    }
 
-    ItemStack result = recipe.assemble(craftingInventory, level.registryAccess());
+    ItemStack result = lastToolMatch == null ? recipe.assemble(craftingInventory, level.registryAccess())
+      : recipe.assemble(lastToolMatch.inventory(), level.registryAccess());
     ForgeHooks.setCraftingPlayer(null);
     return result;
   }
@@ -176,6 +220,7 @@ public class CraftingStationBlockEntity extends RetexturedTableBlockEntity imple
    */
   public void takeResult(Player player, ItemStack result, int amount) {
     CraftingRecipe recipe = this.lastRecipe; // local variable just to prevent race conditions if the field changes, though that is unlikely
+    ToolCraftingResolver.Match toolMatch = this.lastToolMatch;
     if (recipe == null || this.level == null) {
       return;
     }
@@ -191,11 +236,20 @@ public class CraftingStationBlockEntity extends RetexturedTableBlockEntity imple
     // update all slots in the inventory
     // remove remaining items
     ForgeHooks.setCraftingPlayer(player);
-    NonNullList<ItemStack> remaining = recipe.getRemainingItems(craftingInventory);
+    NonNullList<ItemStack> remaining = recipe.getRemainingItems(toolMatch == null ? craftingInventory : toolMatch.inventory());
     ForgeHooks.setCraftingPlayer(null);
     for (int i = 0; i < remaining.size(); ++i) {
       ItemStack original = this.getItem(i);
       ItemStack newStack = remaining.get(i);
+
+      // A virtual GT tool input has no corresponding real grid slot. Never materialize its
+      // remaining stack into the 3x3 inventory; the dedicated tool slot is damaged below.
+      if (toolMatch != null && contains(toolMatch.toolCells(), i)) {
+        continue;
+      }
+      if (original.isEmpty() && !newStack.isEmpty()) {
+        continue;
+      }
 
       // if empty or size 1, set directly (decreases by 1)
       if (original.isEmpty() || original.getCount() == 1) {
@@ -215,6 +269,14 @@ public class CraftingStationBlockEntity extends RetexturedTableBlockEntity imple
         }
       }
     }
+    if (toolMatch != null) {
+      ToolCraftingResolver.damageTools(this, toolMatch, player, amount);
+    }
+  }
+
+  private static boolean contains(int[] values, int value) {
+    for (int candidate : values) if (candidate == value) return true;
+    return false;
   }
 
   /** Sends a message alerting the player this item is currently uncraftable, typically due to gamerules */
@@ -237,8 +299,23 @@ public class CraftingStationBlockEntity extends RetexturedTableBlockEntity imple
   @Override
   public void setItem(int slot, ItemStack itemstack) {
     super.setItem(slot, itemstack);
+    this.cachedToolMatches = null;
+    this.lastToolMatch = null;
     // clear the crafting result when the matrix changes so we recalculate the result
     this.craftingResult.clearContent();
+  }
+
+  private List<ToolCraftingResolver.Match> getToolMatches() {
+    if (this.cachedToolMatches == null && this.level != null) {
+      this.cachedToolMatches = new ArrayList<>(ToolCraftingResolver.findMatches(this, this.level));
+    }
+    return this.cachedToolMatches == null ? Collections.emptyList() : this.cachedToolMatches;
+  }
+
+  /** Invalidates cached tool candidates after direct durability/NBT mutation. */
+  public void invalidateToolMatches() {
+    this.cachedToolMatches = null;
+    this.lastToolMatch = null;
   }
 
 
@@ -261,6 +338,7 @@ public class CraftingStationBlockEntity extends RetexturedTableBlockEntity imple
    */
   public void updateRecipe(CraftingRecipe recipe) {
     this.lastRecipe = recipe;
+    this.lastToolMatch = null;
     this.craftingResult.clearContent();
   }
 

--- a/src/main/java/slimeknights/tconstruct/tables/menu/CraftingStationContainerMenu.java
+++ b/src/main/java/slimeknights/tconstruct/tables/menu/CraftingStationContainerMenu.java
@@ -11,6 +11,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import slimeknights.tconstruct.tables.TinkerTables;
 import slimeknights.tconstruct.tables.block.entity.table.CraftingStationBlockEntity;
 import slimeknights.tconstruct.tables.menu.slot.PlayerSensitiveLazyResultSlot;
+import slimeknights.tconstruct.tables.menu.slot.CraftingStationToolSlot;
 
 import javax.annotation.Nullable;
 
@@ -69,6 +70,12 @@ public class CraftingStationContainerMenu extends TabbedContainerMenu<CraftingSt
         for (int col = 0; col < 3; col++) {
           this.addSlot(new Slot(tile, col + row * 3, 30 + col * 18, 17 + row * 18));
         }
+      }
+      // GT crafting tools live in their own nine single-item slots. They are deliberately
+      // outside the CraftingContainerWrapper used for recipe matching.
+      for (int index = 0; index < CraftingStationBlockEntity.TOOL_SLOT_COUNT; index++) {
+        this.addSlot(new CraftingStationToolSlot(tile, CraftingStationBlockEntity.TOOL_SLOT_START + index,
+          8 + index * 18, 0));
       }
       // add result slot, will fetch result cache
       this.addSlot(resultSlot = new PlayerSensitiveLazyResultSlot(inv.player, tile.getCraftingResult(), 124, 35));
@@ -157,7 +164,10 @@ public class CraftingStationContainerMenu extends TabbedContainerMenu<CraftingSt
           }
           // if successfully added to an inventory, update
           if (!nothingDone) {
-            tile.takeResult(player, result, result.getCount());
+            // The moved stack count is the recipe output count, not the number of
+            // recipe executions. A single shift-click performs one craft, so keep
+            // ingredient consumption and dedicated-tool damage to one use.
+            tile.takeResult(player, result, 1);
             tile.getCraftingResult().clearContent();
             return original;
           }

--- a/src/main/java/slimeknights/tconstruct/tables/menu/slot/CraftingStationToolSlot.java
+++ b/src/main/java/slimeknights/tconstruct/tables/menu/slot/CraftingStationToolSlot.java
@@ -1,0 +1,40 @@
+package slimeknights.tconstruct.tables.menu.slot;
+
+import com.gregtechceu.gtceu.api.item.CustomToolIngredientHelper;
+import com.gregtechceu.gtceu.api.item.IGTTool;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import slimeknights.tconstruct.tables.block.entity.table.CraftingStationBlockEntity;
+
+/** Dedicated GT crafting-tool slot. Tools remain outside the vanilla 3x3 grid. */
+public class CraftingStationToolSlot extends Slot {
+  public CraftingStationToolSlot(CraftingStationBlockEntity container, int index, int x, int y) {
+    super(container, index, x, y);
+  }
+
+  @Override
+  public boolean mayPlace(ItemStack stack) {
+    return stack.isEmpty() || isCraftingTool(stack);
+  }
+
+  @Override
+  public int getMaxStackSize() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxStackSize(ItemStack stack) {
+    return 1;
+  }
+
+  @Override
+  public boolean mayPickup(Player player) {
+    return true;
+  }
+
+  /** Fast broad filter; the recipe resolver performs the exact ToolIngredient check. */
+  public static boolean isCraftingTool(ItemStack stack) {
+    return !stack.isEmpty() && (stack.getItem() instanceof IGTTool || CustomToolIngredientHelper.isCustomTool(stack));
+  }
+}

--- a/src/main/java/slimeknights/tconstruct/tables/recipe/ToolCraftingResolver.java
+++ b/src/main/java/slimeknights/tconstruct/tables/recipe/ToolCraftingResolver.java
@@ -1,0 +1,246 @@
+package slimeknights.tconstruct.tables.recipe;
+
+import com.gregtechceu.gtceu.api.item.CustomToolIngredientHelper;
+import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
+import com.gregtechceu.gtceu.api.recipe.ingredient.ToolIngredient;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+import net.minecraft.world.item.crafting.ShapelessRecipe;
+import net.minecraft.world.level.Level;
+import slimeknights.tconstruct.library.tools.helper.ToolDamageUtil;
+import slimeknights.tconstruct.library.tools.item.ModifiableItem;
+import slimeknights.tconstruct.library.tools.nbt.ToolStack;
+import slimeknights.tconstruct.mixin.gtceu.ToolIngredientAccess;
+import slimeknights.tconstruct.tables.block.entity.inventory.CraftingContainerWrapper;
+import slimeknights.tconstruct.tables.block.entity.table.CraftingStationBlockEntity;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/** Resolves GT ToolIngredient recipes against the station's dedicated tool slots. */
+public final class ToolCraftingResolver {
+  private ToolCraftingResolver() {}
+  private static final Map<net.minecraft.world.item.crafting.RecipeManager, List<CraftingRecipe>> TOOL_RECIPE_CACHE = new WeakHashMap<>();
+
+  public record Match(CraftingRecipe recipe, int[] toolSlots, int[] toolCells, CraftingContainerWrapper inventory) {}
+
+  /** Finds tool recipes matching the station grid without mutating the real grid. */
+  public static List<Match> findMatches(CraftingStationBlockEntity station, Level level) {
+    List<Match> matches = new ArrayList<>();
+    List<CraftingRecipe> recipes;
+    synchronized (TOOL_RECIPE_CACHE) {
+      recipes = TOOL_RECIPE_CACHE.computeIfAbsent(level.getRecipeManager(), manager ->
+        manager.getAllRecipesFor(RecipeType.CRAFTING).stream()
+          .filter(recipe -> containsToolIngredient(recipe.getIngredients()))
+          .toList());
+    }
+    for (CraftingRecipe recipe : recipes) {
+      Match match;
+      if (recipe instanceof ShapedRecipe shaped) {
+        match = resolveShaped(station, level, recipe, shaped);
+      } else if (recipe instanceof ShapelessRecipe) {
+        match = resolveShapeless(station, level, recipe);
+      } else {
+        continue;
+      }
+      if (match != null) {
+        matches.add(match);
+      }
+    }
+    return matches;
+  }
+
+  @Nullable
+  private static Match resolveShapeless(CraftingStationBlockEntity station, Level level, CraftingRecipe recipe) {
+    List<ToolIngredient> tools = new ArrayList<>();
+    List<Ingredient> normal = new ArrayList<>();
+    for (Ingredient ingredient : recipe.getIngredients()) {
+      if (ingredient instanceof ToolIngredient tool) tools.add(tool);
+      else normal.add(ingredient);
+    }
+    int[] normalCells = assignNormalInputs(station, normal, 0, new int[9], new int[normal.size()]);
+    if (normalCells == null) return null;
+    boolean[] usedNormalCells = new boolean[9];
+    for (int cell : normalCells) usedNormalCells[cell] = true;
+    // A shapeless recipe must account for every non-empty grid cell. The previous
+    // virtual container only copied assigned inputs, which accidentally hid unrelated
+    // items from Recipe.matches() and then consumed them during takeResult().
+    for (int cell = 0; cell < 9; cell++) {
+      if (!station.getItem(cell).isEmpty() && !usedNormalCells[cell]) return null;
+    }
+    int[] toolSlots = assignTools(station, tools, 0, 0, new int[tools.size()]);
+    if (toolSlots == null) return null;
+    ItemStack[] virtual = new ItemStack[9];
+    for (int cell = 0; cell < 9; cell++) virtual[cell] = station.getItem(cell).copy();
+    List<Integer> toolCells = new ArrayList<>();
+    for (int cell = 0; cell < 9 && toolCells.size() < tools.size(); cell++) {
+      if (virtual[cell].isEmpty() && station.getItem(cell).isEmpty()) {
+        toolCells.add(cell);
+      }
+    }
+    if (toolCells.size() != tools.size()) return null;
+    for (int i = 0; i < tools.size(); i++) virtual[toolCells.get(i)] = station.getToolStack(toolSlots[i]).copy();
+    CraftingContainerWrapper wrapper = new CraftingContainerWrapper(new SimpleArrayContainer(virtual), 3, 3);
+    return recipe.matches(wrapper, level)
+      ? new Match(recipe, toolSlots, toolCells.stream().mapToInt(Integer::intValue).toArray(), wrapper) : null;
+  }
+
+  @Nullable
+  private static int[] assignNormalInputs(CraftingStationBlockEntity station, List<Ingredient> requirements,
+                                           int requirement, int[] usedCounts, int[] result) {
+    if (requirement == requirements.size()) return result.clone();
+    Ingredient ingredient = requirements.get(requirement);
+    for (int cell = 0; cell < 9; cell++) {
+      ItemStack stack = station.getItem(cell);
+      if (usedCounts[cell] >= stack.getCount()) continue;
+      if (!stack.isEmpty() && ingredient.test(stack.copy())) {
+        result[requirement] = cell;
+        usedCounts[cell]++;
+        int[] assigned = assignNormalInputs(station, requirements, requirement + 1, usedCounts, result);
+        usedCounts[cell]--;
+        if (assigned != null) return assigned;
+      }
+    }
+    return null;
+  }
+
+  public static boolean isStillValid(CraftingStationBlockEntity station, Match match) {
+    if (station.getLevel() == null || !match.recipe().matches(match.inventory(), station.getLevel())) {
+      return false;
+    }
+    for (int i = 0; i < match.toolSlots().length; i++) {
+      ItemStack stack = station.getToolStack(match.toolSlots()[i]);
+      if (stack.isEmpty() || ToolDamageUtil.isBroken(stack)) return false;
+      Ingredient ingredient = match.recipe().getIngredients().stream()
+        .filter(value -> value instanceof ToolIngredient).skip(i).findFirst().orElse(Ingredient.EMPTY);
+      if (!ingredient.test(stack.copy())) return false;
+    }
+    return true;
+  }
+
+  private static boolean containsToolIngredient(List<Ingredient> ingredients) {
+    return ingredients.stream().anyMatch(ingredient -> ingredient instanceof ToolIngredient);
+  }
+
+  @Nullable
+  private static Match resolveShaped(CraftingStationBlockEntity station, Level level,
+                                     CraftingRecipe recipe, ShapedRecipe shaped) {
+    int width = shaped.getWidth();
+    int height = shaped.getHeight();
+    NonNullList<Ingredient> ingredients = recipe.getIngredients();
+    for (boolean mirrored : new boolean[] {false, true}) {
+      for (int offsetY = 0; offsetY <= 3 - height; offsetY++) {
+        for (int offsetX = 0; offsetX <= 3 - width; offsetX++) {
+          ItemStack[] virtual = new ItemStack[9];
+          List<ToolIngredient> tools = new ArrayList<>();
+          List<Integer> toolCells = new ArrayList<>();
+          boolean valid = true;
+          for (int y = 0; y < 3 && valid; y++) {
+            for (int x = 0; x < 3; x++) {
+              int index = x + y * 3;
+              Ingredient ingredient = Ingredient.EMPTY;
+              if (x >= offsetX && x < offsetX + width && y >= offsetY && y < offsetY + height) {
+                int sourceX = mirrored ? width - 1 - (x - offsetX) : x - offsetX;
+                ingredient = ingredients.get(sourceX + (y - offsetY) * width);
+              }
+              ItemStack input = station.getItem(index);
+              if (ingredient instanceof ToolIngredient tool) {
+                tools.add(tool);
+                toolCells.add(index);
+                virtual[index] = ItemStack.EMPTY;
+              } else {
+                if (!ingredient.test(input)) {
+                  valid = false;
+                  break;
+                }
+                virtual[index] = input.copy();
+              }
+            }
+          }
+          if (valid) {
+            int[] assignment = assignTools(station, tools, 0, 0, new int[tools.size()]);
+            if (assignment != null) {
+              for (int i = 0; i < tools.size(); i++) {
+                virtual[toolCells.get(i)] =
+                  station.getToolStack(assignment[i]).copy();
+              }
+              Container backing = new SimpleArrayContainer(virtual);
+              CraftingContainerWrapper wrapper = new CraftingContainerWrapper(backing, 3, 3);
+              if (recipe.matches(wrapper, level)) {
+                return new Match(recipe, assignment, toolCells.stream().mapToInt(Integer::intValue).toArray(), wrapper);
+              }
+            }
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static int[] assignTools(CraftingStationBlockEntity station, List<ToolIngredient> requirements,
+                                   int requirement, int usedMask, int[] result) {
+    if (requirement == requirements.size()) {
+      return result.clone();
+    }
+    ToolIngredient ingredient = requirements.get(requirement);
+    for (int slot = 0; slot < CraftingStationBlockEntity.TOOL_SLOT_COUNT; slot++) {
+      if ((usedMask & (1 << slot)) != 0) continue;
+      ItemStack stack = station.getToolStack(slot);
+      if (stack.isEmpty() || ToolDamageUtil.isBroken(stack)) continue;
+      if (ingredient.test(stack.copy())) {
+        result[requirement] = slot;
+        int[] assigned = assignTools(station, requirements, requirement + 1, usedMask | (1 << slot), result);
+        if (assigned != null) return assigned;
+      }
+    }
+    return null;
+  }
+
+  /** Applies one craft's tool damage after the normal grid inputs are consumed. */
+  public static void damageTools(CraftingStationBlockEntity station, Match match,
+                                 @Nullable LivingEntity user, int amount) {
+    List<Ingredient> ingredients = match.recipe().getIngredients();
+    int toolIndex = 0;
+    for (Ingredient ingredient : ingredients) {
+      if (ingredient instanceof ToolIngredient toolIngredient) {
+        ItemStack stack = station.getToolStack(match.toolSlots()[toolIndex++]);
+        if (stack.isEmpty()) continue;
+        var type = ((ToolIngredientAccess) toolIngredient).tconstruct$getToolType();
+        if (!CustomToolIngredientHelper.damageTool(stack, type, user, amount)) {
+          if (stack.getItem() instanceof ModifiableItem) {
+            ToolDamageUtil.damage(ToolStack.from(stack), amount, user, stack);
+          } else {
+            ToolHelper.damageItem(stack, user, amount);
+          }
+        }
+        station.setChanged();
+      }
+    }
+    station.invalidateToolMatches();
+  }
+
+  /** Minimal mutable container used only for a candidate recipe match. */
+  private static final class SimpleArrayContainer implements Container {
+    private final ItemStack[] stacks;
+    private SimpleArrayContainer(ItemStack[] stacks) { this.stacks = stacks; }
+    public int getContainerSize() { return stacks.length; }
+    public boolean isEmpty() { for (ItemStack stack : stacks) if (!stack.isEmpty()) return false; return true; }
+    public ItemStack getItem(int index) { return stacks[index]; }
+    public ItemStack removeItem(int index, int count) { return ItemStack.EMPTY; }
+    public ItemStack removeItemNoUpdate(int index) { return ItemStack.EMPTY; }
+    public void setItem(int index, ItemStack stack) { stacks[index] = stack; }
+    public void setChanged() {}
+    public boolean stillValid(net.minecraft.world.entity.player.Player player) { return true; }
+    public void clearContent() { java.util.Arrays.fill(stacks, ItemStack.EMPTY); }
+  }
+}

--- a/src/main/resources/tconstruct.mixins.json
+++ b/src/main/resources/tconstruct.mixins.json
@@ -8,7 +8,6 @@
   "mixins": [
     "PlayerHurtSoundMixin",
     "ToolHelperMixin",
-    "gtceu.ToolIngredientMixin",
     "botania.PlayerAncientWillMixin",
     "create.AirCurrentFanProcessingMixin",
     "create.BlazeBurnerBlockEntityTargetMixin",
@@ -16,9 +15,11 @@
     "create.DivingBootsItemMixin",
     "create.GogglesItemMixin",
     "create.WrenchEventHandlerMixin",
+    "gtceu.ToolIngredientAccess",
+    "gtceu.ToolIngredientMixin",
     "tconstruct.create.AlloyerBlockEntityFuelMixin",
-    "tconstruct.create.CastingBlockEntityGoggleTooltipMixin",
     "tconstruct.create.CastingBlockEntityFanProcessingMixin",
+    "tconstruct.create.CastingBlockEntityGoggleTooltipMixin",
     "tconstruct.create.MelterBlockEntityFuelMixin",
     "tconstruct.create.TinyMultiblockControllerBlockMixin"
   ],


### PR DESCRIPTION
- 为工作站增加 9 个专用 GT 工具槽
- 支持 ToolIngredient 配方在工具槽中匹配
- 支持 Shaped 与 Shapeless 工具配方
- 合成时直接消耗工具耐久，不移动工具到 3x3 合成栏
- 优化 EMI 配方转移，不会将工具移动到九宫格里
- 接入 Polymorph 配方冲突选择